### PR TITLE
Allow commas in numeric inputs

### DIFF
--- a/src/statics/tab-config.js
+++ b/src/statics/tab-config.js
@@ -16,7 +16,7 @@
   /** 
    * Helper to convert value to number 
    */
-  let n = (v) => Number(v);
+  let n = (v) => typeof v === "string" ? Number(v.replace(",", ".")) : Number(v);
 
   /**
    * Helper to show/hide custom period inputs


### PR DESCRIPTION
Numeroiden parsinta ei toimi jos käyttää pilkkua desimaalierottimena pisteen sijaan. Kävisi kuitenkin järkeen sallia myös pilkku, sillä käli on suomeksi.